### PR TITLE
Specify C and Fortran flag for CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ```sh
 brew tap wrf-cmake/wrf
-brew install wrf -v
+brew install wrf --HEAD -v
 ```
 
 Note: If you see an error message about an internal compiler error then you're likely running out of memory.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ```sh
 brew tap wrf-cmake/wrf
+# Apple Clang is not supported in latest avalable WRF-CMake release (4.0.3),
+# however this has now been fixed and the fixes are available from the wrf-cmake branch.
+# We pass the `--HEAD` flag to buld WRF-CMake and WPS-CMake from the latest commit from the wrf-cmake branch.
 brew install wrf --HEAD -v
 ```
 

--- a/wrf.rb
+++ b/wrf.rb
@@ -28,6 +28,8 @@ class Wrf < Formula
       (buildpath/"WPS").install resource("WPS")
   
       wrf_args = std_cmake_args + %w[
+        -DCMAKE_C_COMPILER=gcc
+        -DCMAKE_Fortran_COMPILER=gfortran
         -DNESTING=basic
         -DMODE=dmpar
       ]
@@ -41,6 +43,8 @@ class Wrf < Formula
       # which is not installed. Therefore, we build it here and install it in the WPS subfolder
       # of WRF.
       wps_args = std_cmake_args + %W[
+        -DCMAKE_C_COMPILER=gcc
+        -DCMAKE_Fortran_COMPILER=gfortran
         -DCMAKE_INSTALL_PREFIX=#{prefix}/WPS
         -DWRF_DIR=#{buildpath}/build
       ]


### PR DESCRIPTION
Fixes #1 and #3.
Fix tested locally on macOS 10.14.5 with multiple C and Fortran compilers installed (default `icc`, `ifort`). 