### PR TITLE
Style fixes & alternate to PR #2

### DIFF
--- a/wrf-cmake.rb
+++ b/wrf-cmake.rb
@@ -1,7 +1,7 @@
 # WRF-CMake (https://github.com/WRF-CMake/WRF).
 # Copyright 2019 M. Riechert and D. Meyer. Licensed under the MIT License.
 
-class Wrf < Formula
+class WrfCmake < Formula
   desc "The Weather Research and Forecasting (WRF) model with CMake support"
   homepage "https://github.com/WRF-CMake/WRF"
   url "https://github.com/WRF-CMake/WRF.git",

--- a/wrf-cmake.rb
+++ b/wrf-cmake.rb
@@ -34,7 +34,8 @@ class WrfCmake < Formula
     # Prevent CMake from finding & using ifort
     ENV["FC"] = Formula["gcc"].opt_bin/"gfortran"
 
-    wrf_args = std_cmake_args + %w[
+    wrf_args = *std_cmake_args.map + %W[
+      -DCMAKE_INSTALL_PREFIX=#{prefix}/wrf
       -DNESTING=basic
       -DMODE=dmpar
     ]
@@ -48,7 +49,7 @@ class WrfCmake < Formula
     # which is not installed. Therefore, we build it here and install it in the WPS subfolder
     # of WRF.
     wps_args = std_cmake_args + %W[
-      -DCMAKE_INSTALL_PREFIX=#{prefix}/WPS
+      -DCMAKE_INSTALL_PREFIX=#{prefix}/wps
       -DWRF_DIR=#{buildpath}/build
     ]
 

--- a/wrf-cmake.rb
+++ b/wrf-cmake.rb
@@ -30,7 +30,7 @@ class WrfCmake < Formula
     # Prevent CMake from finding & using ifort
     ENV["FC"] = Formula["gcc"].opt_bin/"gfortran"
 
-    wrf_args = *std_cmake_args.map + %W[
+    wrf_args = *std_cmake_args + %W[
       -DCMAKE_INSTALL_PREFIX=#{prefix}/wrf
       -DNESTING=basic
       -DMODE=dmpar

--- a/wrf-cmake.rb
+++ b/wrf-cmake.rb
@@ -24,10 +24,6 @@ class WrfCmake < Formula
         :commit => "d918dc6da17b177aa1fe0082866274968f45a171"
   end
 
-  # Note: If you get an internal compiler error when building WRF,
-  # then you're likely running out of memory. To reduce memory usage,
-  # set HOMEBREW_MAKE_JOBS=1.
-
   def install
     (buildpath/"WPS").install resource("WPS")
 
@@ -57,6 +53,13 @@ class WrfCmake < Formula
       system "cmake", "..", *wps_args
       system "make", "install"
     end
+  end
+
+  def caveats; <<~EOS
+    If you get an internal compiler error when building WRF,
+    then you're likely running out of memory. To reduce memory usage,
+    set HOMEBREW_MAKE_JOBS=1.
+  EOS
   end
 
   test do

--- a/wrf.rb
+++ b/wrf.rb
@@ -8,17 +8,17 @@ class Wrf < Formula
   sha256 "37814ee7bfe7077cba8bd0175258ef763380fce3e7d8aab2ea8360a902a11043"
   head "https://github.com/WRF-CMake/WRF.git", :branch => "wrf-cmake"
 
+  depends_on "cmake" => :build
+  depends_on "gcc" # for gfortran
+  depends_on "jasper"
+  depends_on "libpng"
+  depends_on "netcdf"
+  depends_on "open-mpi"
+
   resource "WPS" do
     url "https://github.com/WRF-CMake/WPS/archive/WPS-CMake-4.0.2.tar.gz"
     sha256 "40c1efd14ac9f4b562b3a333aed62c6840d877ecd97d8b5280f4861d7681a331"
   end
-
-  depends_on "cmake" => :build
-  depends_on "gcc" # for gfortran
-  depends_on "netcdf"
-  depends_on "jasper"
-  depends_on "libpng"
-  depends_on "open-mpi"
 
   # Note: If you get an internal compiler error when building WRF,
   # then you're likely running out of memory. To reduce memory usage,

--- a/wrf.rb
+++ b/wrf.rb
@@ -2,66 +2,65 @@
 # Copyright 2019 M. Riechert and D. Meyer. Licensed under the MIT License.
 
 class Wrf < Formula
-    desc "The Weather Research and Forecasting (WRF) model with CMake support"
-    homepage "https://github.com/WRF-CMake/WRF"
-    url "https://github.com/WRF-CMake/WRF/archive/WRF-CMake-4.0.3.tar.gz"
-    sha256 "37814ee7bfe7077cba8bd0175258ef763380fce3e7d8aab2ea8360a902a11043"
-    head "https://github.com/WRF-CMake/WRF.git", :branch => "wrf-cmake"
-  
-    resource "WPS" do
-      url "https://github.com/WRF-CMake/WPS/archive/WPS-CMake-4.0.2.tar.gz"
-      sha256 "40c1efd14ac9f4b562b3a333aed62c6840d877ecd97d8b5280f4861d7681a331"
+  desc "The Weather Research and Forecasting (WRF) model with CMake support"
+  homepage "https://github.com/WRF-CMake/WRF"
+  url "https://github.com/WRF-CMake/WRF/archive/WRF-CMake-4.0.3.tar.gz"
+  sha256 "37814ee7bfe7077cba8bd0175258ef763380fce3e7d8aab2ea8360a902a11043"
+  head "https://github.com/WRF-CMake/WRF.git", :branch => "wrf-cmake"
+
+  resource "WPS" do
+    url "https://github.com/WRF-CMake/WPS/archive/WPS-CMake-4.0.2.tar.gz"
+    sha256 "40c1efd14ac9f4b562b3a333aed62c6840d877ecd97d8b5280f4861d7681a331"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "gcc" # for gfortran
+  depends_on "netcdf"
+  depends_on "jasper"
+  depends_on "libpng"
+  depends_on "open-mpi"
+
+  # Note: If you get an internal compiler error when building WRF,
+  # then you're likely running out of memory. To reduce memory usage,
+  # set HOMEBREW_MAKE_JOBS=1.
+
+  def install
+    (buildpath/"WPS").install resource("WPS")
+
+    wrf_args = std_cmake_args + %w[
+      -DNESTING=basic
+      -DMODE=dmpar
+    ]
+
+    mkdir "build" do
+      system "cmake", "..", *wrf_args
+      system "make", "install"
     end
-      
-    depends_on "cmake" => :build
-    depends_on "gcc" # for gfortran
-    depends_on "netcdf"
-    depends_on "jasper"
-    depends_on "libpng" 
-    depends_on "open-mpi"
-  
-    # Note: If you get an internal compiler error when building WRF,
-    # then you're likely running out of memory. To reduce memory usage,
-    # set HOMEBREW_MAKE_JOBS=1.
-  
-    def install
-      (buildpath/"WPS").install resource("WPS")
-  
-      wrf_args = std_cmake_args + %w[
-        -DNESTING=basic
-        -DMODE=dmpar
-      ]
-  
-      mkdir "build" do
-        system "cmake", "..", *wrf_args
-        system "make", "install"
-      end
-  
-      # Ideally, WPS should be a separate formula, but it relies on the build tree of WRF,
-      # which is not installed. Therefore, we build it here and install it in the WPS subfolder
-      # of WRF.
-      wps_args = std_cmake_args + %W[
-        -DCMAKE_INSTALL_PREFIX=#{prefix}/WPS
-        -DWRF_DIR=#{buildpath}/build
-      ]
-  
-      mkdir "WPS/build" do
-        system "cmake", "..", *wps_args
-        system "make", "install"
-      end
-    end
-  
-    test do
-      # `test do` will create, run in and delete a temporary directory.
-      #
-      # This test will fail and we won't accept that! For Homebrew/homebrew-core
-      # this will need to be a test that verifies the functionality of the
-      # software. Run the test with `brew test WRF`. Options passed
-      # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
-      #
-      # The installed folder is not in the path, so use the entire path to any
-      # executables being tested: `system "#{bin}/program", "do", "something"`.
-      system "false"
+
+    # Ideally, WPS should be a separate formula, but it relies on the build tree of WRF,
+    # which is not installed. Therefore, we build it here and install it in the WPS subfolder
+    # of WRF.
+    wps_args = std_cmake_args + %W[
+      -DCMAKE_INSTALL_PREFIX=#{prefix}/WPS
+      -DWRF_DIR=#{buildpath}/build
+    ]
+
+    mkdir "WPS/build" do
+      system "cmake", "..", *wps_args
+      system "make", "install"
     end
   end
-  
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! For Homebrew/homebrew-core
+    # this will need to be a test that verifies the functionality of the
+    # software. Run the test with `brew test WRF`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end

--- a/wrf.rb
+++ b/wrf.rb
@@ -4,7 +4,10 @@
 class Wrf < Formula
   desc "The Weather Research and Forecasting (WRF) model with CMake support"
   homepage "https://github.com/WRF-CMake/WRF"
-  url "https://github.com/WRF-CMake/WRF/archive/WRF-CMake-4.0.3.tar.gz"
+  url "https://github.com/WRF-CMake/WRF.git",
+      :branch => "wrf-cmake",
+      :commit => "8b9edc944f0cbbfb22966850ae3724f617f0f705"
+  version "4.1.wrf-cmake"
   sha256 "37814ee7bfe7077cba8bd0175258ef763380fce3e7d8aab2ea8360a902a11043"
   head "https://github.com/WRF-CMake/WRF.git", :branch => "wrf-cmake"
 

--- a/wrf.rb
+++ b/wrf.rb
@@ -19,8 +19,9 @@ class Wrf < Formula
   depends_on "open-mpi"
 
   resource "WPS" do
-    url "https://github.com/WRF-CMake/WPS/archive/WPS-CMake-4.0.2.tar.gz"
-    sha256 "40c1efd14ac9f4b562b3a333aed62c6840d877ecd97d8b5280f4861d7681a331"
+    url "https://github.com/WRF-CMake/WPS.git",
+        :branch => "wps-cmake",
+        :commit => "d918dc6da17b177aa1fe0082866274968f45a171"
   end
 
   # Note: If you get an internal compiler error when building WRF,

--- a/wrf.rb
+++ b/wrf.rb
@@ -31,6 +31,9 @@ class Wrf < Formula
   def install
     (buildpath/"WPS").install resource("WPS")
 
+    # Prevent CMake from finding & using ifort
+    ENV["FC"] = Formula["gcc"].opt_bin/"gfortran"
+
     wrf_args = std_cmake_args + %w[
       -DNESTING=basic
       -DMODE=dmpar


### PR DESCRIPTION
I've split this PR over three commits.

- The first is mostly white-space changes. Most of the changes can be made via `brew style --fix wrf`
- The second is to address audit failures. Again, `brew audit --strict --fix wrf` will do most of the work for you
- Lastly use a non-stable git repo & branch & sha as the version until there is a new stable release so that users can build with clang.

This is a proposed alternative to PR #2. You're welcome to ignore it though. This should resolve #1, in that it does things the canonical homebrew way, and enables compilation with or without `--HEAD`. (But it doesn't switch the C compiler to GCC). To do that a user could do `brew install --cc=gcc-9 --build-from-source wrf` if they so desired, although I wouldn't recommend it to them without a good reason.